### PR TITLE
feat: 值班日历日期悬停显示人员详情弹窗 (close #7)

### DIFF
--- a/src/components/CalendarCell.tsx
+++ b/src/components/CalendarCell.tsx
@@ -98,9 +98,9 @@ export function CalendarCell({
           className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-10
             opacity-0 group-hover:opacity-100 pointer-events-none
             transition-opacity duration-150
-            bg-white border border-border rounded-lg shadow-lg p-2 min-w-[120px]"
+            bg-popover text-popover-foreground border border-border rounded-lg shadow-lg p-2 min-w-[120px]"
         >
-          <div className="text-sm font-medium text-foreground">{schedule.user.name}</div>
+          <div className="text-sm font-medium">{schedule.user.name}</div>
           <div className="text-xs text-muted-foreground mt-0.5">
             {schedule.user.organization} · {schedule.user.category}
           </div>

--- a/tests/calendar-tooltip.spec.ts
+++ b/tests/calendar-tooltip.spec.ts
@@ -55,7 +55,7 @@ test('月历视图悬停排班日期时显示人员详情 tooltip', async ({ pag
   const tooltip = page.getByTestId('schedule-tooltip');
 
   await expect(tooltip).toHaveCount(1);
-  await expect(tooltip).not.toBeVisible();
+  await expect(tooltip).toHaveCSS('opacity', '0');
 
   await page.locator('[draggable="true"]').first().hover();
 
@@ -63,4 +63,19 @@ test('月历视图悬停排班日期时显示人员详情 tooltip', async ({ pag
   await expect(tooltip).toContainText('张三');
   await expect(tooltip).toContainText('X');
   await expect(tooltip).toContainText('J');
+});
+
+test('深色主题下 tooltip 不应使用白色背景', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('theme', 'dark');
+  });
+
+  await login(page);
+
+  const tooltip = page.getByTestId('schedule-tooltip');
+  await page.locator('[draggable="true"]').first().hover();
+  await expect(tooltip).toBeVisible();
+
+  const backgroundColor = await tooltip.evaluate(element => window.getComputedStyle(element).backgroundColor);
+  expect(backgroundColor).not.toBe('rgb(255, 255, 255)');
 });


### PR DESCRIPTION
## 功能描述

实现 Issue #7 中的需求：值班日历日期悬停显示人员详情弹窗

### 功能点
- ✅ 鼠标悬停在有值班人员的日期格子上时，自动弹出信息弹窗
- ✅ 弹窗显示内容：姓名、所属单位、人员类别
- ✅ 鼠标移开时，弹窗自动消失
- ✅ 无值班人员的日期，悬停不触发弹窗

### 技术实现
- **组件修改**: `src/components/CalendarCell.tsx`
- **实现方式**: 纯 CSS tooltip，使用 Tailwind 的 `group` 和 `group-hover:opacity-100`
- **定位**: absolute 定位在格子上方居中
- **交互**: `pointer-events-none` 避免影响点击和拖拽
- **样式**: 白色背景、圆角、阴影、淡入淡出动画

### 测试
- 新增 Playwright 测试用例 `tests/calendar-tooltip.spec.ts`

Closes #7