### PR TITLE
fix: 修复月历拖到非日历区域后残留拖动态（close #26）

### DIFF
--- a/src/components/CalendarCell.tsx
+++ b/src/components/CalendarCell.tsx
@@ -15,6 +15,7 @@ interface CalendarCellProps {
   isSelected?: boolean;
   onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
   onDragStart?: () => void;
+  onDragEnd?: () => void;
   onDragOver?: (e: React.DragEvent) => void;
   onDrop?: () => void;
   isDragSource?: boolean;
@@ -31,6 +32,7 @@ export function CalendarCell({
   isSelected = false,
   onClick,
   onDragStart,
+  onDragEnd,
   onDragOver,
   onDrop,
   isDragSource = false,
@@ -49,6 +51,7 @@ export function CalendarCell({
       onClick={onClick}
       draggable={canManage && !!schedule}
       onDragStart={canManage ? onDragStart : undefined}
+      onDragEnd={canManage ? onDragEnd : undefined}
       onDragOver={canManage ? onDragOver : undefined}
       onDrop={canManage ? onDrop : undefined}
       className={cn(

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -30,6 +30,7 @@ interface MonthCalendarProps {
   selectedDates: Set<string>;
   onCellClick: (date: Date, event: React.MouseEvent<HTMLDivElement>) => void;
   onDragStart: (date: string) => void;
+  onDragEnd: () => void;
   onDragOver: (e: React.DragEvent) => void;
   onDrop: (date: string) => void;
   canManage: boolean;
@@ -44,6 +45,7 @@ function MonthCalendar({
   selectedDates,
   onCellClick,
   onDragStart,
+  onDragEnd,
   onDragOver,
   onDrop,
   canManage,
@@ -89,6 +91,7 @@ function MonthCalendar({
               isSelected={selectedDates.has(dateStr)}
               onClick={event => onCellClick(day, event)}
               onDragStart={() => onDragStart(dateStr)}
+              onDragEnd={onDragEnd}
               onDragOver={onDragOver}
               onDrop={() => onDrop(dateStr)}
               isDragSource={dragDate === dateStr}
@@ -299,6 +302,10 @@ export function CalendarView({ refreshKey, canManage }: CalendarViewProps) {
     setDragDate(date);
   };
 
+  const handleDragEnd = () => {
+    setDragDate(null);
+  };
+
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
   };
@@ -427,6 +434,7 @@ export function CalendarView({ refreshKey, canManage }: CalendarViewProps) {
           selectedDates={selectedDates}
           onCellClick={handleCellClick}
           onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
           onDragOver={handleDragOver}
           onDrop={handleDrop}
           canManage={canManage}
@@ -441,6 +449,7 @@ export function CalendarView({ refreshKey, canManage }: CalendarViewProps) {
           selectedDates={selectedDates}
           onCellClick={handleCellClick}
           onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
           onDragOver={handleDragOver}
           onDrop={handleDrop}
           canManage={canManage}

--- a/tests/calendar-move-schedule.spec.ts
+++ b/tests/calendar-move-schedule.spec.ts
@@ -33,11 +33,26 @@ test('月历视图中可将排班从有人的日期拖到空日期', async ({ pa
 
   await expect(page.getByRole('heading', { name: '值班日历' })).toBeVisible();
 
-  const sourceCell = page.locator('div').filter({ hasText: /^16张$/ }).first();
-  const targetCell = page.locator('div').filter({ hasText: /^17$/ }).first();
+  const sourceCell = page.locator('[data-calendar-date="2026-03-16"][draggable="true"]').first();
+  const targetCell = page.locator('[data-calendar-date="2026-03-17"]').first();
 
   await sourceCell.dragTo(targetCell);
 
-  await expect(page.locator('div').filter({ hasText: /^17张$/ }).first()).toBeVisible();
-  await expect(page.locator('div').filter({ hasText: /^16张$/ })).toHaveCount(0);
+  await expect
+    .poll(() => db.prepare('SELECT date FROM schedules WHERE user_id = 1').get()?.date)
+    .toBe('2026-03-17');
+});
+
+test('拖到非日历区域结束后应清理拖动态', async ({ page }) => {
+  await login(page);
+
+  const sourceCell = page.locator('[data-calendar-date="2026-03-16"][draggable="true"]').first();
+
+  await sourceCell.dispatchEvent('dragstart', {
+    dataTransfer: await page.evaluateHandle(() => new DataTransfer()),
+  });
+  await expect(sourceCell).toHaveClass(/opacity-40/);
+
+  await sourceCell.dispatchEvent('dragend');
+  await expect(sourceCell).not.toHaveClass(/opacity-40/);
 });


### PR DESCRIPTION
## 变更说明
- 给月历日历格补充 dragend 收尾，拖拽结束后统一清理拖动态
- 保持原有成功拖放的移动/交换逻辑不变
- 补充无效拖拽结束回归测试，并把原拖拽用例改成稳定定位

## 验证
- npx playwright test "tests/calendar-move-schedule.spec.ts" --reporter=line --workers=1
- npm run lint