### PR TITLE
feat: 导入排班时自动补全值班领导 (fixes #48)

### DIFF
--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -18,6 +18,7 @@ import { moveScheduleWithReason, swapSchedulesWithReason } from '@/lib/schedule-
 import { revalidatePath } from 'next/cache';
 import { buildScheduleTemplateWorkbookByType } from '@/lib/imports/schedule-import-template';
 import { importScheduleRows, previewScheduleImport } from '@/lib/imports/schedule-import';
+import { backfillLeaderSchedules, getDefaultLeaderId, getLeaderSchedulesByDates, setLeaderSchedule } from '@/lib/leader-schedules';
 import type { AutoScheduleStartMode, ScheduleImportStrategy, ScheduleImportTemplateType } from '@/types';
 import type { ScheduleImportPreview } from '@/types';
 import type { ScheduleImportSuccessResult } from '@/lib/imports/schedule-import';
@@ -359,6 +360,9 @@ export async function importScheduleAction(
     getUserByName,
     getSchedulesByDates,
     setSchedule,
+    getDefaultLeaderId,
+    getLeaderSchedulesByDates,
+    setLeaderSchedule,
   }, templateType);
 
   if (!result.success) {
@@ -386,4 +390,23 @@ export async function importScheduleAction(
   }
 
   return result;
+}
+
+export async function backfillLeaderSchedulesAction(): Promise<{ success: boolean; error?: string; filledCount?: number }> {
+  const account = await requireAdmin();
+
+  try {
+    const filledCount = backfillLeaderSchedules();
+    await addWebLog(
+      'backfill_leader_schedules',
+      '批量补全值班领导',
+      undefined,
+      `已补全 ${filledCount} 条`,
+      { username: account.username, role: account.role }
+    );
+    revalidatePath('/dashboard');
+    return { success: true, filledCount };
+  } catch (error) {
+    return { success: false, error: (error as Error).message };
+  }
 }

--- a/src/components/DashboardHomeClient.tsx
+++ b/src/components/DashboardHomeClient.tsx
@@ -7,6 +7,8 @@ import { CalendarView } from '@/components/CalendarView';
 import { ListView } from '@/components/ListView';
 import { Button } from '@/components/ui/button';
 import { ScheduleImportDialog } from '@/components/ScheduleImportDialog';
+import { backfillLeaderSchedulesAction } from '@/app/actions/schedule';
+import { toast } from 'sonner';
 import type { AccountRole } from '@/types';
 
 type ViewMode = 'calendar' | 'list';
@@ -20,10 +22,30 @@ export function DashboardHomeClient({ role }: DashboardHomeClientProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('calendar');
   const [refreshKey, setRefreshKey] = useState(0);
   const [importOpen, setImportOpen] = useState(false);
+  const [backfilling, setBackfilling] = useState(false);
   const canManage = role === 'admin';
 
   const handleScheduleGenerated = () => {
     setRefreshKey(key => key + 1);
+  };
+
+  const handleBackfillLeaderSchedules = async () => {
+    setBackfilling(true);
+    try {
+      const result = await backfillLeaderSchedulesAction();
+      if (result.success) {
+        toast.success(`已补全 ${result.filledCount} 条值班领导排班`);
+        if (result.filledCount! > 0) {
+          handleScheduleGenerated();
+        }
+      } else {
+        toast.error(result.error ?? '补全失败');
+      }
+    } catch {
+      toast.error('补全失败');
+    } finally {
+      setBackfilling(false);
+    }
   };
 
   const handleOpenScheduleGenerator = () => {
@@ -53,7 +75,10 @@ export function DashboardHomeClient({ role }: DashboardHomeClientProps) {
 
         <main className="flex-1 p-4 bg-muted/30 overflow-y-auto">
           {canManage ? (
-            <div className="mb-4 flex justify-end">
+            <div className="mb-4 flex justify-end gap-2">
+              <Button variant="outline" onClick={handleBackfillLeaderSchedules} disabled={backfilling}>
+                {backfilling ? '补全中...' : '补全值班领导'}
+              </Button>
               <Button onClick={() => setImportOpen(true)}>导入排班</Button>
             </div>
           ) : null}

--- a/src/lib/imports/schedule-import.ts
+++ b/src/lib/imports/schedule-import.ts
@@ -296,13 +296,14 @@ export async function importScheduleRows(
 
   // 预加载已有领导排班日期，用于补全时判断是否需要设置
   let existingLeaderDates: Set<string> | undefined;
-  if (dependencies.getDefaultLeaderId && dependencies.setLeaderSchedule && dependencies.getLeaderSchedulesByDates) {
+  const { getDefaultLeaderId, setLeaderSchedule, getLeaderSchedulesByDates } = dependencies;
+  if (getDefaultLeaderId && setLeaderSchedule && getLeaderSchedulesByDates) {
     const allImportDates = preview.rows.map(row => row.date);
-    const existingLeaderSchedules = dependencies.getLeaderSchedulesByDates(allImportDates);
+    const existingLeaderSchedules = getLeaderSchedulesByDates(allImportDates);
     existingLeaderDates = new Set(existingLeaderSchedules.map(s => s.date));
   }
 
-  const defaultLeaderId = dependencies.getDefaultLeaderId?.();
+  const defaultLeaderId = getDefaultLeaderId?.();
 
   for (const row of preview.rows) {
     if (conflictDates.has(row.date) && strategy === 'skip') {
@@ -313,8 +314,8 @@ export async function importScheduleRows(
     dependencies.setSchedule(row.date, row.userId, row.isManual);
 
     // 补全值班领导：有默认领导且该日期无领导排班时自动设置
-    if (defaultLeaderId && existingLeaderDates && !existingLeaderDates.has(row.date)) {
-      dependencies.setLeaderSchedule!(row.date, defaultLeaderId, false);
+    if (defaultLeaderId && existingLeaderDates && setLeaderSchedule && !existingLeaderDates.has(row.date)) {
+      setLeaderSchedule(row.date, defaultLeaderId, false);
       existingLeaderDates.add(row.date);
     }
 

--- a/src/lib/imports/schedule-import.ts
+++ b/src/lib/imports/schedule-import.ts
@@ -9,6 +9,9 @@ export type ScheduleImportDependencies = {
   getUserByName: (name: string) => ImportUser | undefined;
   getSchedulesByDates: (dates: string[]) => ExistingSchedule[];
   setSchedule: (date: string, userId: number, isManual: boolean) => void;
+  getDefaultLeaderId?: () => number | null;
+  getLeaderSchedulesByDates?: (dates: string[]) => { date: string }[];
+  setLeaderSchedule?: (date: string, leaderId: number, isManual?: boolean) => void;
 };
 
 export type ScheduleImportSuccessResult = {
@@ -291,6 +294,16 @@ export async function importScheduleRows(
   let skippedCount = 0;
   let overwrittenCount = 0;
 
+  // 预加载已有领导排班日期，用于补全时判断是否需要设置
+  let existingLeaderDates: Set<string> | undefined;
+  if (dependencies.getDefaultLeaderId && dependencies.setLeaderSchedule && dependencies.getLeaderSchedulesByDates) {
+    const allImportDates = preview.rows.map(row => row.date);
+    const existingLeaderSchedules = dependencies.getLeaderSchedulesByDates(allImportDates);
+    existingLeaderDates = new Set(existingLeaderSchedules.map(s => s.date));
+  }
+
+  const defaultLeaderId = dependencies.getDefaultLeaderId?.();
+
   for (const row of preview.rows) {
     if (conflictDates.has(row.date) && strategy === 'skip') {
       skippedCount += 1;
@@ -298,6 +311,13 @@ export async function importScheduleRows(
     }
 
     dependencies.setSchedule(row.date, row.userId, row.isManual);
+
+    // 补全值班领导：有默认领导且该日期无领导排班时自动设置
+    if (defaultLeaderId && existingLeaderDates && !existingLeaderDates.has(row.date)) {
+      dependencies.setLeaderSchedule!(row.date, defaultLeaderId, false);
+      existingLeaderDates.add(row.date);
+    }
+
     importedCount += 1;
 
     if (conflictDates.has(row.date) && strategy === 'overwrite') {

--- a/src/lib/leader-schedules.ts
+++ b/src/lib/leader-schedules.ts
@@ -66,3 +66,28 @@ export function getDefaultLeaderId(): number | null {
 export function setDefaultLeaderId(id: number | null): void {
   db.prepare("INSERT OR REPLACE INTO config (key, value) VALUES ('default_leader_id', ?)").run(id ? String(id) : '');
 }
+
+export function backfillLeaderSchedules(): number {
+  const defaultLeaderId = getDefaultLeaderId();
+  if (!defaultLeaderId) return 0;
+
+  // 查找有排班但无领导排班的日期
+  const missingDates = db.prepare(`
+    SELECT s.date FROM schedules s
+    LEFT JOIN leader_schedules ls ON s.date = ls.date
+    WHERE ls.date IS NULL
+    ORDER BY s.date
+  `).all() as { date: string }[];
+
+  if (missingDates.length === 0) return 0;
+
+  const insert = db.prepare(
+    'INSERT OR IGNORE INTO leader_schedules (date, leader_id, is_manual) VALUES (?, ?, 0)'
+  );
+
+  for (const { date } of missingDates) {
+    insert.run(date, defaultLeaderId);
+  }
+
+  return missingDates.length;
+}

--- a/src/lib/leader-schedules.ts
+++ b/src/lib/leader-schedules.ts
@@ -85,9 +85,14 @@ export function backfillLeaderSchedules(): number {
     'INSERT OR IGNORE INTO leader_schedules (date, leader_id, is_manual) VALUES (?, ?, 0)'
   );
 
-  for (const { date } of missingDates) {
-    insert.run(date, defaultLeaderId);
-  }
+  const backfill = db.transaction(() => {
+    let count = 0;
+    for (const { date } of missingDates) {
+      const result = insert.run(date, defaultLeaderId);
+      count += result.changes;
+    }
+    return count;
+  });
 
-  return missingDates.length;
+  return backfill();
 }


### PR DESCRIPTION
## Summary

- 导入排班时自动为有值班人员但无值班领导的日期设置默认领导（与自动排班逻辑一致）
- 新增 `backfillLeaderSchedules` 函数和 `backfillLeaderSchedulesAction`，支持一键批量补全历史缺失数据
- 工具栏新增"补全值班领导"按钮（仅管理员可见）

## Changes

| 文件 | 改动 |
|------|------|
| `src/lib/imports/schedule-import.ts` | 扩展依赖类型，导入时预加载已有领导排班并补全缺失 |
| `src/lib/leader-schedules.ts` | 新增 `backfillLeaderSchedules()` 批量补全函数 |
| `src/app/actions/schedule.ts` | 导入依赖传入领导相关函数，新增 `backfillLeaderSchedulesAction` |
| `src/components/DashboardHomeClient.tsx` | 工具栏添加"补全值班领导"按钮 |

## Test plan

- [ ] 导入排班后确认有值班人员的日期自动设置了值班领导
- [ ] 已有值班领导的日期不被覆盖
- [ ] 点击"补全值班领导"按钮补全历史缺失数据
- [ ] 未设置默认领导时功能不报错（跳过补全）
- [ ] 非管理员不显示"补全值班领导"按钮

🤖 Generated with [Claude Code](https://claude.com/claude-code)