### PR TITLE
feat: 管理员日历视图右键添加日期备注功能

### DIFF
--- a/src/app/actions/date-notes.ts
+++ b/src/app/actions/date-notes.ts
@@ -1,0 +1,38 @@
+// src/app/actions/date-notes.ts
+'use server';
+
+import { requireAdmin } from '@/lib/auth';
+import { getDateNote, getDateNotesByDateRange, setDateNote, deleteDateNote } from '@/lib/date-notes';
+import { revalidatePath } from 'next/cache';
+
+export async function getDateNoteAction(date: string) {
+  return getDateNote(date);
+}
+
+export async function getDateNotesByRangeAction(startDate: string, endDate: string) {
+  return getDateNotesByDateRange(startDate, endDate);
+}
+
+export async function saveDateNoteAction(date: string, content: string) {
+  const account = await requireAdmin();
+
+  try {
+    setDateNote(date, content);
+    revalidatePath('/dashboard');
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: (error as Error).message };
+  }
+}
+
+export async function deleteDateNoteAction(date: string) {
+  const account = await requireAdmin();
+
+  try {
+    deleteDateNote(date);
+    revalidatePath('/dashboard');
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: (error as Error).message };
+  }
+}

--- a/src/components/CalendarCell.tsx
+++ b/src/components/CalendarCell.tsx
@@ -6,7 +6,7 @@ import { memo } from 'react';
 import type { ScheduleWithUser, LeaderScheduleWithLeader } from '@/types';
 import { getAvatarColor, getAvatarInitial } from '@/lib/avatar';
 import { cn } from '@/lib/utils';
-import { Plus } from 'lucide-react';
+import { Plus, StickyNote } from 'lucide-react';
 import { format } from 'date-fns';
 
 interface CalendarCellProps {
@@ -31,6 +31,8 @@ interface CalendarCellProps {
   holidayName?: string;
   /** 拖拽预览：被拖拽的用户信息 */
   dragPreviewUser?: { id: number; name: string };
+  /** 日期备注内容 */
+  dateNote?: string;
 }
 
 const CalendarCellInner = memo(function CalendarCellInner({
@@ -54,6 +56,7 @@ const CalendarCellInner = memo(function CalendarCellInner({
   isHoliday = false,
   holidayName,
   dragPreviewUser,
+  dateNote,
 }: CalendarCellProps) {
   const day = date.getDate();
   const isWeekend = date.getDay() === 0 || date.getDay() === 6;
@@ -106,6 +109,13 @@ const CalendarCellInner = memo(function CalendarCellInner({
       {/* 手动调整标记 */}
       {schedule?.is_manual && (viewMode !== 'leader' || leaderSchedule) && (
         <div className="absolute top-1 left-1 w-2 h-2 rounded-full bg-amber-500" />
+      )}
+
+      {/* 日期备注标记 */}
+      {dateNote && (
+        <div className="absolute top-1 left-1 w-2 h-2 rounded-full bg-blue-500" title="该日期有备注">
+          <StickyNote className="w-2 h-2 text-white" />
+        </div>
       )}
 
       {/* 节假日标记 */}
@@ -328,6 +338,37 @@ const CalendarCellInner = memo(function CalendarCellInner({
           <div className="text-xs text-muted-foreground mt-0.5">
             {schedule.user.organization} · {schedule.user.category}
           </div>
+          {/* 备注信息 */}
+          {dateNote && (
+            <div className="mt-2 pt-2 border-t border-border">
+              <div className="text-xs font-medium text-blue-600 dark:text-blue-400 flex items-center gap-1">
+                <StickyNote className="w-3 h-3" />
+                备注
+              </div>
+              <div className="text-xs text-muted-foreground mt-0.5 whitespace-pre-wrap max-w-[200px]">
+                {dateNote}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 只有备注没有排班时的悬浮提示 */}
+      {!schedule && dateNote && viewMode !== 'leader' && (
+        <div
+          data-testid="note-tooltip"
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-10
+            opacity-0 group-hover:opacity-100 pointer-events-none
+            transition-opacity duration-150
+            bg-popover text-popover-foreground border border-border rounded-lg shadow-lg p-2 min-w-[120px]"
+        >
+          <div className="text-xs font-medium text-blue-600 dark:text-blue-400 flex items-center gap-1">
+            <StickyNote className="w-3 h-3" />
+            备注
+          </div>
+          <div className="text-xs text-muted-foreground mt-0.5 whitespace-pre-wrap max-w-[200px]">
+            {dateNote}
+          </div>
         </div>
       )}
 
@@ -342,6 +383,18 @@ const CalendarCellInner = memo(function CalendarCellInner({
         >
           <div className="text-sm font-medium">{leaderSchedule.leader.name}</div>
           <div className="text-xs text-muted-foreground mt-0.5">值班领导</div>
+          {/* 备注信息 */}
+          {dateNote && (
+            <div className="mt-2 pt-2 border-t border-border">
+              <div className="text-xs font-medium text-blue-600 dark:text-blue-400 flex items-center gap-1">
+                <StickyNote className="w-3 h-3" />
+                备注
+              </div>
+              <div className="text-xs text-muted-foreground mt-0.5 whitespace-pre-wrap max-w-[200px]">
+                {dateNote}
+              </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/CalendarContextMenu.tsx
+++ b/src/components/CalendarContextMenu.tsx
@@ -7,7 +7,8 @@ export type CalendarContextMenuAction =
   | 'assign_user'
   | 'replace_user'
   | 'move_schedule'
-  | 'delete_schedule';
+  | 'delete_schedule'
+  | 'edit_note';
 
 interface CalendarContextMenuProps {
   open: boolean;
@@ -22,12 +23,14 @@ interface CalendarContextMenuProps {
 const emptyDateActions: Array<{ key: CalendarContextMenuAction; label: string }> = [
   { key: 'auto_schedule', label: '自动排班' },
   { key: 'assign_user', label: '安排值班人员' },
+  { key: 'edit_note', label: '添加/编辑备注' },
 ];
 
 const scheduledDateActions: Array<{ key: CalendarContextMenuAction; label: string }> = [
   { key: 'replace_user', label: '替换值班人员' },
   { key: 'move_schedule', label: '移动到其他日期' },
   { key: 'delete_schedule', label: '删除排班' },
+  { key: 'edit_note', label: '添加/编辑备注' },
 ];
 
 export function CalendarContextMenu({

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -19,6 +19,8 @@ import { exportSelectedSchedulesToXLSX } from '@/app/actions/export';
 import { useSchedules, useInvalidateSchedules } from '@/hooks/useSchedules';
 import { useLeaderSchedules, useInvalidateLeaderSchedules } from '@/hooks/useLeaderSchedules';
 import { useAssignableUsers } from '@/hooks/useUsers';
+import { useDateNotes, useInvalidateDateNotes } from '@/hooks/useDateNotes';
+import { DateNoteDialog } from './DateNoteDialog';
 import type { AutoScheduleStartMode, ScheduleWithUser, User, LeaderScheduleWithLeader, Leader } from '@/types';
 import { Button } from '@/components/ui/button';
 import { ChevronLeft, ChevronRight, User as UserIcon, UserCircle } from 'lucide-react';
@@ -73,6 +75,7 @@ interface MonthCalendarProps {
   onDragOver: (e: React.DragEvent) => void;
   onDrop: (date: string) => void;
   canManage: boolean;
+  dateNotes?: Map<string, string>;
 }
 
 const MonthCalendar = memo(function MonthCalendar({
@@ -91,6 +94,7 @@ const MonthCalendar = memo(function MonthCalendar({
   onDragOver,
   onDrop,
   canManage,
+  dateNotes,
 }: MonthCalendarProps) {
   // 使用 useMemo 缓存日期计算
   const days = useMemo(() => {
@@ -165,6 +169,7 @@ const MonthCalendar = memo(function MonthCalendar({
               animationDelay={animationDelay}
               displayMode={displayMode}
               canManage={canManage}
+              dateNote={dateNotes?.get(dateStr)}
             />
           );
         })}
@@ -193,6 +198,8 @@ export function CalendarView({ refreshKey, canManage, onRequestGenerate }: Calen
   const [contextMenuState, setContextMenuState] = useState<ContextMenuState | null>(null);
   const [autoScheduleDate, setAutoScheduleDate] = useState<string | null>(null);
   const [autoScheduleError, setAutoScheduleError] = useState<string | null>(null);
+  const [dateNoteDialogOpen, setDateNoteDialogOpen] = useState(false);
+  const [selectedDateNote, setSelectedDateNote] = useState<string>('');
   const hasCustomizedDisplayModeRef = useRef(false);
   const contextMenuTriggerRef = useRef<HTMLElement | null>(null);
 
@@ -203,8 +210,19 @@ export function CalendarView({ refreshKey, canManage, onRequestGenerate }: Calen
   const { data: schedules = [], isLoading: isLoadingSchedules, refetch: refetchSchedules } = useSchedules(currentMonth);
   const { data: leaderSchedules = [], isLoading: isLoadingLeaderSchedules } = useLeaderSchedules(currentMonth);
   const { data: users = [], isLoading: isLoadingUsers } = useAssignableUsers();
+  const { data: dateNotesData = [] } = useDateNotes(currentMonth);
   const invalidateSchedules = useInvalidateSchedules();
   const invalidateLeaderSchedules = useInvalidateLeaderSchedules();
+  const invalidateDateNotes = useInvalidateDateNotes();
+
+  // 构建日期备注 Map
+  const dateNotesMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const note of dateNotesData) {
+      map.set(note.date, note.content);
+    }
+    return map;
+  }, [dateNotesData]);
 
   // 获取领导列表（用于选择对话框）
   const [leaders, setLeaders] = useState<Leader[]>([]);
@@ -711,6 +729,14 @@ export function CalendarView({ refreshKey, canManage, onRequestGenerate }: Calen
         await removeSchedule(targetDate);
         await refreshData();
       })();
+      return;
+    }
+
+    if (action === 'edit_note') {
+      const noteContent = dateNotesMap.get(targetDate) ?? '';
+      setSelectedDateNote(noteContent);
+      setDateNoteDialogOpen(true);
+      return;
     }
   };
 
@@ -864,6 +890,7 @@ export function CalendarView({ refreshKey, canManage, onRequestGenerate }: Calen
             onDragOver={handleDragOver}
             onDrop={handleDrop}
             canManage={canManage}
+            dateNotes={dateNotesMap}
           />
           {isMobileSingleMonthLayout ? null : (
             <MonthCalendar
@@ -883,6 +910,7 @@ export function CalendarView({ refreshKey, canManage, onRequestGenerate }: Calen
               onDragOver={handleDragOver}
               onDrop={handleDrop}
               canManage={canManage}
+              dateNotes={dateNotesMap}
             />
           )}
         </div>
@@ -968,6 +996,21 @@ export function CalendarView({ refreshKey, canManage, onRequestGenerate }: Calen
           }}
           onBatchDelete={() => {
             void handleBatchDelete();
+          }}
+        />
+      ) : null}
+
+      {canManage ? (
+        <DateNoteDialog
+          open={dateNoteDialogOpen}
+          date={selectedDate}
+          initialContent={selectedDateNote}
+          onClose={() => {
+            setDateNoteDialogOpen(false);
+            setSelectedDateNote('');
+          }}
+          onSuccess={() => {
+            void invalidateDateNotes(currentMonth);
           }}
         />
       ) : null}

--- a/src/components/DateNoteDialog.tsx
+++ b/src/components/DateNoteDialog.tsx
@@ -1,0 +1,134 @@
+// src/components/DateNoteDialog.tsx
+'use client';
+
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { useSaveDateNote, useDeleteDateNote } from '@/hooks/useDateNotes';
+import { format, parseISO } from 'date-fns';
+import { zhCN } from 'date-fns/locale';
+import { StickyNote, Trash2 } from 'lucide-react';
+
+interface DateNoteDialogProps {
+  open: boolean;
+  date: string | null;
+  initialContent?: string;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+export function DateNoteDialog({
+  open,
+  date,
+  initialContent = '',
+  onClose,
+  onSuccess,
+}: DateNoteDialogProps) {
+  const [content, setContent] = useState(initialContent);
+  const saveMutation = useSaveDateNote();
+  const deleteMutation = useDeleteDateNote();
+
+  useEffect(() => {
+    if (open) {
+      setContent(initialContent);
+    }
+  }, [open, initialContent]);
+
+  const handleSave = async () => {
+    if (!date) return;
+
+    try {
+      await saveMutation.mutateAsync({ date, content: content.trim() });
+      onSuccess?.();
+      onClose();
+    } catch (error) {
+      // Error is handled by mutation
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!date) return;
+
+    const confirmed = window.confirm('确定要删除该日期的备注吗？');
+    if (!confirmed) return;
+
+    try {
+      await deleteMutation.mutateAsync(date);
+      onSuccess?.();
+      onClose();
+    } catch (error) {
+      // Error is handled by mutation
+    }
+  };
+
+  const formattedDate = date
+    ? format(parseISO(date), 'yyyy年M月d日', { locale: zhCN })
+    : '';
+
+  const isLoading = saveMutation.isPending || deleteMutation.isPending;
+  const isEmpty = !content.trim();
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <StickyNote className="w-5 h-5" />
+            日期备注
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="py-4 space-y-4">
+          <div className="text-sm text-muted-foreground">
+            {formattedDate}
+          </div>
+
+          <Textarea
+            placeholder="请输入备注内容..."
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            rows={5}
+            className="resize-none"
+            disabled={isLoading}
+          />
+
+          <div className="text-xs text-muted-foreground">
+            提示：备注内容支持多行文本，保存后会在日历中显示备注标识
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          {initialContent && (
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isLoading}
+              className="gap-1"
+            >
+              <Trash2 className="w-4 h-4" />
+              删除
+            </Button>
+          )}
+          <Button variant="outline" onClick={onClose} disabled={isLoading}>
+            取消
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={isLoading || isEmpty}
+            className="gap-1"
+          >
+            <StickyNote className="w-4 h-4" />
+            保存
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/useDateNotes.ts
+++ b/src/hooks/useDateNotes.ts
@@ -1,0 +1,78 @@
+// src/hooks/useDateNotes.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getDateNotesByRangeAction, saveDateNoteAction, deleteDateNoteAction } from '@/app/actions/date-notes';
+import type { DateNote } from '@/lib/date-notes';
+import { format, startOfMonth, endOfMonth } from 'date-fns';
+
+const DATE_NOTES_KEY = 'dateNotes';
+
+function getMonthKey(date: Date): string {
+  return format(date, 'yyyy-MM');
+}
+
+function getMonthRange(date: Date): { start: string; end: string } {
+  const start = format(startOfMonth(date), 'yyyy-MM-dd');
+  const end = format(endOfMonth(date), 'yyyy-MM-dd');
+  return { start, end };
+}
+
+export function useDateNotes(month: Date) {
+  const monthKey = getMonthKey(month);
+  const { start, end } = getMonthRange(month);
+
+  return useQuery({
+    queryKey: [DATE_NOTES_KEY, monthKey],
+    queryFn: async () => {
+      const notes = await getDateNotesByRangeAction(start, end);
+      return notes as DateNote[];
+    },
+  });
+}
+
+export function useInvalidateDateNotes() {
+  const queryClient = useQueryClient();
+
+  return async (month?: Date) => {
+    if (month) {
+      const monthKey = getMonthKey(month);
+      await queryClient.invalidateQueries({ queryKey: [DATE_NOTES_KEY, monthKey] });
+    } else {
+      await queryClient.invalidateQueries({ queryKey: [DATE_NOTES_KEY] });
+    }
+  };
+}
+
+export function useSaveDateNote() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ date, content }: { date: string; content: string }) => {
+      const result = await saveDateNoteAction(date, content);
+      if (!result.success) {
+        throw new Error(result.error || '保存备注失败');
+      }
+      return result;
+    },
+    onSuccess: () => {
+      // Invalidate all date notes queries
+      queryClient.invalidateQueries({ queryKey: [DATE_NOTES_KEY] });
+    },
+  });
+}
+
+export function useDeleteDateNote() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (date: string) => {
+      const result = await deleteDateNoteAction(date);
+      if (!result.success) {
+        throw new Error(result.error || '删除备注失败');
+      }
+      return result;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [DATE_NOTES_KEY] });
+    },
+  });
+}

--- a/src/lib/date-notes.ts
+++ b/src/lib/date-notes.ts
@@ -1,0 +1,42 @@
+// src/lib/date-notes.ts
+import db from './db';
+
+export interface DateNote {
+  id: number;
+  date: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export function getDateNote(date: string): DateNote | undefined {
+  const note = db.prepare('SELECT * FROM date_notes WHERE date = ?').get(date) as DateNote | undefined;
+  return note;
+}
+
+export function getDateNotesByDateRange(startDate: string, endDate: string): DateNote[] {
+  const notes = db.prepare(
+    'SELECT * FROM date_notes WHERE date >= ? AND date <= ? ORDER BY date'
+  ).all(startDate, endDate) as DateNote[];
+  return notes;
+}
+
+export function setDateNote(date: string, content: string): void {
+  const now = new Date().toISOString();
+  db.prepare(`
+    INSERT INTO date_notes (date, content, created_at, updated_at)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(date) DO UPDATE SET
+      content = excluded.content,
+      updated_at = excluded.updated_at
+  `).run(date, content, now, now);
+}
+
+export function deleteDateNote(date: string): void {
+  db.prepare('DELETE FROM date_notes WHERE date = ?').run(date);
+}
+
+export function hasDateNote(date: string): boolean {
+  const result = db.prepare('SELECT 1 FROM date_notes WHERE date = ? LIMIT 1').get(date);
+  return !!result;
+}

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -36,6 +36,24 @@ function addColumnIfMissing(database: Database.Database, tableName: string, colu
 
 export const MIGRATIONS: Migration[] = [
   {
+    version: '009_date_notes',
+    up(database) {
+      // 创建日期备注表
+      database.exec(`
+        CREATE TABLE IF NOT EXISTS date_notes (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          date TEXT NOT NULL UNIQUE,
+          content TEXT NOT NULL,
+          created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_date_notes_date ON date_notes(date);
+      `);
+    },
+  },
+
+  {
     version: '001_initial_schema',
     up(database) {
       database.exec(`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -200,3 +200,11 @@ export interface LeaderSchedule {
 export interface LeaderScheduleWithLeader extends LeaderSchedule {
   leader: Leader;
 }
+
+export interface DateNote {
+  id: number;
+  date: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## 功能描述

实现 Issue #51 要求的管理员日历视图右键备注功能。

## 主要变更

### 后端
- 新增 `date_notes` 表存储日期备注（数据库迁移 009）
- 添加 `src/lib/date-notes.ts` 服务层，提供 CRUD 操作
- 添加 `src/app/actions/date-notes.ts` Server Actions，仅管理员可调用

### 前端
- 新增 `src/hooks/useDateNotes.ts` React Query hook
- 创建 `src/components/DateNoteDialog.tsx` 备注编辑弹窗组件
- 更新 `CalendarContextMenu` 添加「添加/编辑备注」菜单项
- 更新 `CalendarCell`：
  - 显示蓝色备注标记（左上角）
  - 悬浮提示中显示备注内容
- 更新 `CalendarView` 集成备注数据获取和弹窗

## 功能特性

1. **权限控制**：仅管理员角色可见并使用右键菜单选项
2. **备注编辑**：支持多行文本，可保存、修改、删除
3. **视觉标识**：带备注的日期显示蓝色标记
4. **悬浮预览**：鼠标悬浮时显示备注内容
5. **数据隔离**：备注与排班数据独立，互不影响

## 测试建议

- [ ] 管理员右键日历单元格，显示「添加/编辑备注」选项
- [ ] 添加备注后，日期单元格显示蓝色标记
- [ ] 悬浮提示正确显示备注内容
- [ ] 非管理员用户看不到备注菜单选项
- [ ] 备注可正常编辑和删除

Closes #51