### PR TITLE
fix: 优化日历卡片橙色圆点提示规则

### DIFF
--- a/src/components/CalendarCell.tsx
+++ b/src/components/CalendarCell.tsx
@@ -106,16 +106,9 @@ const CalendarCellInner = memo(function CalendarCellInner({
         {day}
       </div>
 
-      {/* 手动调整标记 */}
-      {schedule?.is_manual && (viewMode !== 'leader' || leaderSchedule) && (
-        <div className="absolute top-1 left-1 w-2 h-2 rounded-full bg-amber-500" />
-      )}
-
-      {/* 日期备注标记 */}
-      {dateNote && (
-        <div className="absolute top-1 left-1 w-2 h-2 rounded-full bg-blue-500" title="该日期有备注">
-          <StickyNote className="w-2 h-2 text-white" />
-        </div>
+      {/* 人工干预标记：换班或备注时显示 */}
+      {(showOriginalAndCurrent || dateNote) && (viewMode !== 'leader' || leaderSchedule) && (
+        <div className="absolute top-1 left-1 w-2 h-2 rounded-full bg-amber-500" title={dateNote ? '该日期有换班或备注' : '该日期有换班'} />
       )}
 
       {/* 节假日标记 */}


### PR DESCRIPTION
## 问题描述

Issue #52：当前系统中，人工导入的排班会默认显示橙色圆点提示，与业务实际需求不符。

## 解决方案

优化橙色圆点的显示逻辑：
- **仅当存在人工干预/异常操作时才显示橙色圆点**：
  - 换班（original_user_id 存在）
  - 有日期备注
- **不再显示橙色圆点的情况**：
  - 系统自动生成的排班
  - 人工导入的正常排班

## 变更内容

- 修改 `CalendarCell.tsx` 中的橙色圆点显示条件
- 从基于 `is_manual` 改为基于 `showOriginalAndCurrent || dateNote`

## 测试建议

- [ ] 换班后的日期显示橙色圆点
- [ ] 有备注的日期显示橙色圆点
- [ ] 人工导入的正常排班不显示橙色圆点
- [ ] 系统自动生成的排班不显示橙色圆点

Closes #52