### PR TITLE
feat(api): 新增 /api/schedules/stats 值班统计端点 + 节假日按年自动拉取

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,54 @@ curl -X PATCH "http://localhost:3000/api/leader-schedules/2026-03-16" \
   -d '{"leaderId":1}'
 ```
 
+### 值班统计
+
+按时间范围聚合每人值班次数，并附节假日维度分类（法定节假日 / 周末 / 调休补班）。时间参数三选一：`start`+`end`、`year` 或 `month`（自动处理闰年 2 月）。
+
+```bash
+# 查询 2026 全年（等价于 ?start=2026-01-01&end=2026-12-31）
+curl "http://localhost:3000/api/schedules/stats?year=2026" \
+  -H "Authorization: Bearer <your-token>"
+
+# 查询某月：?month=2026-06
+```
+
+返回示例：
+
+```json
+{
+  "range": { "start": "2026-01-01", "end": "2026-12-31" },
+  "total": 4,
+  "userCount": 2,
+  "stats": [
+    {
+      "userId": 1,
+      "userName": "张三",
+      "count": 3,
+      "restDayCount": 2,
+      "holidayCount": 1,
+      "adjustedWorkdayCount": 1,
+      "dates": ["2026-01-01", "2026-01-04", "2026-01-10"],
+      "restDays": [
+        { "date": "2026-01-01", "name": "元旦", "type": "holiday" },
+        { "date": "2026-01-10", "type": "weekend" }
+      ]
+    }
+  ]
+}
+```
+
+字段说明：
+
+| 字段 | 含义 |
+|---|---|
+| `total` / `userCount` | 区间内总值班次数 / 涉及人数 |
+| `count` | 该人员区间内值班天数 |
+| `restDayCount` | 非工作日值班天数（法定节假日 + 周末 − 调休补班） |
+| `holidayCount` | 法定节假日值班天数 |
+| `adjustedWorkdayCount` | 调休补班值班天数 |
+| `restDays` | 非工作日明细，`type` 为 `holiday`（带 `name`）或 `weekend` |
+
 ### Token 管理接口
 
 - `GET /api/tokens`
@@ -314,11 +362,11 @@ curl -X PATCH "http://localhost:3000/api/leader-schedules/2026-03-16" \
 
 ### 节假日与休息日统计
 
-系统内置中国法定节假日数据（当前覆盖 2025-2026 年），统计页支持：
+系统运行时按年自动拉取中国法定节假日（数据源 [NateScarlet/holiday-cn](https://github.com/NateScarlet/holiday-cn)，基于国务院通知），内置 2025-2026 数据作为离线兜底。统计页支持：
 
 - 按人员统计非工作日值班天数（含周末和法定节假日，排除调休补班日）
 - 人员值班日期列表中标注节假日名称
-- 节假日数据每年随版本更新
+- 节假日数据按年自动拉取，拉取失败时回退到内置数据
 
 ### 审计日志
 

--- a/src/app/api/schedules/stats/route.ts
+++ b/src/app/api/schedules/stats/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateApiRequest } from '@/lib/api-auth';
+import { apiError } from '@/lib/api-errors';
+import { withApiRequestLog } from '@/lib/api-logging';
+import { getScheduleStats } from '@/lib/schedules';
+import { getUserById } from '@/lib/users';
+import { summarizeDutyDates } from '@/lib/duty-summary';
+import { resolveStatsRange } from '@/lib/stats-range';
+import { ensureHolidaysLoaded } from '@/lib/holidays';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  return withApiRequestLog(
+    request,
+    async auth => {
+      if (!auth) {
+        return apiError(401, 'UNAUTHORIZED', 'Invalid or disabled token');
+      }
+
+      const params = request.nextUrl.searchParams;
+      const range = resolveStatsRange({
+        start: params.get('start'),
+        end: params.get('end'),
+        year: params.get('year'),
+        month: params.get('month'),
+      });
+
+      if (!range) {
+        return apiError(400, 'INVALID_INPUT', 'provide start+end, year, or month');
+      }
+
+      // best-effort 拉取区间内各年份的法定节假日（失败自动回退到静态基线）
+      const startYear = Number(range.start.slice(0, 4));
+      const endYear = Number(range.end.slice(0, 4));
+      const years: number[] = [];
+      for (let y = startYear; y <= endYear; y++) years.push(y);
+      await ensureHolidaysLoaded(years);
+
+      const rawStats = getScheduleStats(range.start, range.end);
+
+      const stats = rawStats.map(s => {
+        const summary = summarizeDutyDates(s.dates);
+        return {
+          userId: s.userId,
+          userName: getUserById(s.userId)?.name ?? '未知',
+          count: s.count,
+          restDayCount: summary.restDayCount,
+          holidayCount: summary.holidayCount,
+          adjustedWorkdayCount: summary.adjustedWorkdayCount,
+          dates: s.dates,
+          restDays: summary.restDays,
+        };
+      });
+
+      return NextResponse.json({
+        range,
+        total: stats.reduce((sum, s) => sum + s.count, 0),
+        userCount: stats.length,
+        stats,
+      });
+    },
+    {
+      loadContext: authenticateApiRequest,
+      getActor: auth => auth
+        ? {
+          username: `token:${auth.token.name}`,
+          role: auth.account.role,
+        }
+        : {
+          username: 'anonymous',
+          role: null,
+        },
+    }
+  );
+}

--- a/src/app/api/schedules/stats/route.ts
+++ b/src/app/api/schedules/stats/route.ts
@@ -5,7 +5,7 @@ import { withApiRequestLog } from '@/lib/api-logging';
 import { getScheduleStats } from '@/lib/schedules';
 import { getUserById } from '@/lib/users';
 import { summarizeDutyDates } from '@/lib/duty-summary';
-import { resolveStatsRange } from '@/lib/stats-range';
+import { resolveStatsRange, holidayYearsForRange } from '@/lib/stats-range';
 import { ensureHolidaysLoaded } from '@/lib/holidays';
 
 export const dynamic = 'force-dynamic';
@@ -30,11 +30,12 @@ export async function GET(request: NextRequest) {
         return apiError(400, 'INVALID_INPUT', 'provide start+end, year, or month');
       }
 
-      // best-effort 拉取区间内各年份的法定节假日（失败自动回退到静态基线）
-      const startYear = Number(range.start.slice(0, 4));
-      const endYear = Number(range.end.slice(0, 4));
-      const years: number[] = [];
-      for (let y = startYear; y <= endYear; y++) years.push(y);
+      // best-effort 拉取区间相关年份的法定节假日（含相邻年；失败自动回退到静态基线）。
+      // 跨度过大返回 400，避免触发海量并发拉取。
+      const years = holidayYearsForRange(range.start, range.end);
+      if (!years) {
+        return apiError(400, 'INVALID_INPUT', 'range too wide (max 10 years)');
+      }
       await ensureHolidaysLoaded(years);
 
       const rawStats = getScheduleStats(range.start, range.end);

--- a/src/lib/duty-summary.ts
+++ b/src/lib/duty-summary.ts
@@ -1,0 +1,67 @@
+// src/lib/duty-summary.ts
+// 纯函数模块：将值班日期列表分类为「非工作日 / 法定节假日 / 调休补班」。
+// 仅依赖 ./holidays（纯日期数据），不触碰数据库，便于单元测试。
+
+import { getHolidayInfo } from './holidays';
+
+export type RestDayType = 'holiday' | 'weekend';
+
+export interface RestDayDetail {
+  date: string;
+  /** 仅法定节假日带名称；周末为 undefined（序列化时省略该字段） */
+  name?: string;
+  type: RestDayType;
+}
+
+export interface DutyDateSummary {
+  /** 非工作日值班天数 = 法定节假日 + 周末 - 调休补班 */
+  restDayCount: number;
+  /** 法定节假日（非补班）值班天数 */
+  holidayCount: number;
+  /** 调休补班值班天数（算工作日，不归入休息日） */
+  adjustedWorkdayCount: number;
+  /** 非工作日值班明细，按日期升序 */
+  restDays: RestDayDetail[];
+}
+
+/**
+ * 对单个人员的值班日期列表做节假日维度的分类统计。
+ *
+ * 分类优先级：调休补班 > 法定节假日 > 普通周末。
+ * 与 src/lib/holidays.ts 的 isRestDay 语义保持一致。
+ */
+export function summarizeDutyDates(dates: string[]): DutyDateSummary {
+  const restDays: RestDayDetail[] = [];
+  let holidayCount = 0;
+  let adjustedWorkdayCount = 0;
+
+  for (const date of dates) {
+    const info = getHolidayInfo(date);
+
+    // 调休补班日 → 工作日，单独计数
+    if (info?.isWorkday) {
+      adjustedWorkdayCount++;
+      continue;
+    }
+    // 法定节假日（非补班）→ 休息日
+    if (info && !info.isWorkday) {
+      holidayCount++;
+      restDays.push({ date, name: info.name, type: 'holiday' });
+      continue;
+    }
+    // 普通周末（周六 / 周日）→ 休息日
+    const day = new Date(date + 'T00:00:00').getDay();
+    if (day === 0 || day === 6) {
+      restDays.push({ date, type: 'weekend' });
+    }
+  }
+
+  restDays.sort((a, b) => a.date.localeCompare(b.date));
+
+  return {
+    restDayCount: restDays.length,
+    holidayCount,
+    adjustedWorkdayCount,
+    restDays,
+  };
+}

--- a/src/lib/holidays.ts
+++ b/src/lib/holidays.ts
@@ -8,6 +8,13 @@ export interface HolidayInfo {
   isWorkday?: boolean; // 调休补班日
 }
 
+/** holiday-cn 数据源的原始条目形状 */
+interface HolidayCnDay {
+  name: string;
+  date: string;
+  isOffDay: boolean; // true=放假，false=调休补班
+}
+
 const holidays: HolidayInfo[] = [
   // === 2025 年 ===
   // 元旦
@@ -115,9 +122,64 @@ for (const h of holidays) {
   holidayMap.set(h.date, h);
 }
 
-/** 查询某日期是否为法定节假日 */
+// --- 动态拉取的节假日（运行时覆盖静态基线，拉取失败自动回退） ---
+// 数据源：NateScarlet/holiday-cn（基于国务院办公厅通知，MIT 协议）
+const dynamicHolidayMap = new Map<string, HolidayInfo>();
+const loadedYears = new Set<number>();
+const HOLIDAY_CN_BASE = 'https://cdn.jsdelivr.net/gh/NateScarlet/holiday-cn@master';
+
+/** 把 holiday-cn 的 days 数组解析为 HolidayInfo[]（纯函数，便于单元测试） */
+export function parseHolidayCnDays(days: unknown): HolidayInfo[] {
+  if (!Array.isArray(days)) return [];
+  const result: HolidayInfo[] = [];
+  for (const d of days) {
+    if (!d || typeof d !== 'object') continue;
+    const day = d as HolidayCnDay;
+    if (
+      typeof day.name !== 'string' ||
+      typeof day.date !== 'string' ||
+      typeof day.isOffDay !== 'boolean' ||
+      !/^\d{4}-\d{2}-\d{2}$/.test(day.date)
+    ) {
+      continue;
+    }
+    result.push(day.isOffDay ? { name: day.name, date: day.date } : { name: day.name, date: day.date, isWorkday: true });
+  }
+  return result;
+}
+
+/** 拉取某一年的法定节假日（best-effort：失败返回 null，不抛错） */
+export async function fetchHolidaysForYear(year: number, timeoutMs = 3000): Promise<HolidayInfo[] | null> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(`${HOLIDAY_CN_BASE}/${year}.json`, { signal: controller.signal });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const json = (await res.json()) as { days?: unknown };
+    return parseHolidayCnDays(json.days);
+  } catch {
+    return null;
+  }
+}
+
+/** 确保给定年份的节假日已加载到动态缓存（best-effort；拉取失败的年份下次请求会重试） */
+export async function ensureHolidaysLoaded(years: number[]): Promise<void> {
+  const missing = years.filter(y => !loadedYears.has(y));
+  if (missing.length === 0) return;
+  await Promise.all(
+    missing.map(async year => {
+      const days = await fetchHolidaysForYear(year);
+      if (days === null) return; // 拉取失败：不标记为已加载，下次请求重试
+      loadedYears.add(year);
+      for (const d of days) dynamicHolidayMap.set(d.date, d);
+    }),
+  );
+}
+
+/** 查询某日期是否为法定节假日（优先动态拉取数据，回退到静态基线） */
 export function getHolidayInfo(date: string): HolidayInfo | undefined {
-  return holidayMap.get(date);
+  return dynamicHolidayMap.get(date) ?? holidayMap.get(date);
 }
 
 /** 判断某日期是否为法定节假日（非补班日） */

--- a/src/lib/stats-range.ts
+++ b/src/lib/stats-range.ts
@@ -1,0 +1,48 @@
+// src/lib/stats-range.ts
+// 纯函数：把 stats 端点的多种时间参数归一化为 [start, end] 日期范围。
+// 不依赖任何第三方库，便于单元测试（含闰年 2 月末尾的边界）。
+
+export interface StatsRangeInput {
+  start?: string | null;
+  end?: string | null;
+  year?: string | null;
+  month?: string | null;
+}
+
+export interface ResolvedRange {
+  start: string;
+  end: string;
+}
+
+/**
+ * 解析时间范围参数，优先级：start+end > month > year。
+ * 返回 null 表示参数缺失或非法（调用方应回 400）。
+ */
+export function resolveStatsRange(input: StatsRangeInput): ResolvedRange | null {
+  const { start, end, year, month } = input;
+
+  if (start && end) {
+    return { start, end };
+  }
+
+  if (month) {
+    const m = /^(\d{4})-(\d{2})$/.exec(month);
+    if (!m) return null;
+    const yearNum = Number(m[1]);
+    const monthNum = Number(m[2]);
+    if (monthNum < 1 || monthNum > 12) return null;
+    // day=0 取上月最后一天 → 即本月最后一天（自动处理闰年）
+    const lastDay = new Date(yearNum, monthNum, 0).getDate();
+    return {
+      start: `${m[1]}-${m[2]}-01`,
+      end: `${m[1]}-${m[2]}-${String(lastDay).padStart(2, '0')}`,
+    };
+  }
+
+  if (year) {
+    if (!/^\d{4}$/.test(year)) return null;
+    return { start: `${year}-01-01`, end: `${year}-12-31` };
+  }
+
+  return null;
+}

--- a/src/lib/stats-range.ts
+++ b/src/lib/stats-range.ts
@@ -14,6 +14,9 @@ export interface ResolvedRange {
   end: string;
 }
 
+/** 查询跨度上限（含），用于防止超大区间触发海量节假日拉取（fan-out 滥用） */
+export const MAX_STATS_SPAN_YEARS = 10;
+
 /**
  * 解析时间范围参数，优先级：start+end > month > year。
  * 返回 null 表示参数缺失或非法（调用方应回 400）。
@@ -45,4 +48,23 @@ export function resolveStatsRange(input: StatsRangeInput): ResolvedRange | null 
   }
 
   return null;
+}
+
+/**
+ * 计算某个 [start, end] 区间需要预加载节假日的年份列表。
+ *
+ * - 返回 [startYear-1 .. endYear+1]：holiday-cn 会把跨年边界的日期
+ *   （如 2011-12-31）存进相邻年份文件（2012.json），需多加载相邻年。
+ * - 跨度超过 MAX_STATS_SPAN_YEARS 返回 null（防止 ?start=0000&end=9999
+ *   之类的请求触发上万次并发拉取）。
+ */
+export function holidayYearsForRange(start: string, end: string): number[] | null {
+  const startYear = Number(start.slice(0, 4));
+  const endYear = Number(end.slice(0, 4));
+  if (Number.isNaN(startYear) || Number.isNaN(endYear)) return null;
+  if (endYear - startYear + 1 > MAX_STATS_SPAN_YEARS) return null;
+
+  const years = new Set<number>();
+  for (let y = startYear - 1; y <= endYear + 1; y++) years.add(y);
+  return [...years];
 }

--- a/tests/api-schedules-stats.spec.ts
+++ b/tests/api-schedules-stats.spec.ts
@@ -1,0 +1,170 @@
+import path from 'path';
+import Database from 'better-sqlite3';
+import { expect, test } from 'playwright/test';
+import { hashPassword } from '../src/lib/password';
+
+const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000';
+const adminUsername = process.env.PLAYWRIGHT_USERNAME || 'admin';
+const adminPassword = process.env.PLAYWRIGHT_PASSWORD || '123456';
+const db = new Database(path.join(process.cwd(), 'data', 'scheduling.db'));
+
+// 复用 /api/schedules 测试的种子方式，并补充节假日相关排班：
+//  - 2026-01-01 元旦（法定节假日）
+//  - 2026-01-04 元旦调休补班（工作日）
+//  - 2026-01-10 周六（周末）
+//  - 2026-03-16 周一（普通工作日）
+function seedSchedules() {
+  db.prepare('DELETE FROM schedules').run();
+  db.prepare('DELETE FROM users').run();
+  db.prepare('DELETE FROM logs').run();
+  try {
+    db.prepare('DELETE FROM api_tokens').run();
+  } catch {
+    // 表尚未创建时忽略
+  }
+
+  db.prepare('UPDATE accounts SET password_hash = ?, role = ?, is_active = 1 WHERE username = ?')
+    .run(hashPassword(adminPassword), 'admin', adminUsername);
+
+  db.prepare('INSERT INTO users (id, name, sort_order, is_active) VALUES (1, ?, 1, 1)').run('张三');
+  db.prepare('INSERT INTO users (id, name, sort_order, is_active) VALUES (2, ?, 2, 1)').run('李四');
+
+  // 张三：元旦（节假日）+ 元旦补班（调休）+ 周六（周末）= 3 天
+  db.prepare('INSERT INTO schedules (date, user_id, is_manual) VALUES (?, ?, 0)').run('2026-01-01', 1);
+  db.prepare('INSERT INTO schedules (date, user_id, is_manual) VALUES (?, ?, 0)').run('2026-01-04', 1);
+  db.prepare('INSERT INTO schedules (date, user_id, is_manual) VALUES (?, ?, 0)').run('2026-01-10', 1);
+  // 李四：周一普通工作日 = 1 天
+  db.prepare('INSERT INTO schedules (date, user_id, is_manual) VALUES (?, ?, 0)').run('2026-03-16', 2);
+}
+
+async function login(page: import('playwright/test').Page, username: string, password: string) {
+  await page.goto(baseUrl);
+  await page.getByLabel('用户名').fill(username);
+  await page.getByLabel('登录密码').fill(password);
+  await page.getByRole('button', { name: '登录系统' }).click();
+  await page.waitForURL('**/dashboard');
+}
+
+async function createToken(page: import('playwright/test').Page, name = 'api-stats-token') {
+  const result = await page.evaluate(async (tokenName) => {
+    const response = await fetch('/api/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: tokenName }),
+    });
+
+    return await response.json();
+  }, name);
+
+  return result.token as string;
+}
+
+test.beforeEach(() => {
+  seedSchedules();
+});
+
+test('缺少 Bearer Token 时返回 401', async ({ request }) => {
+  const response = await request.get(`${baseUrl}/api/schedules/stats?start=2026-01-01&end=2026-12-31`);
+
+  expect(response.status()).toBe(401);
+  await expect(response.json()).resolves.toMatchObject({
+    error: {
+      code: 'UNAUTHORIZED',
+    },
+  });
+});
+
+test('缺少 start 或 end 参数时返回 400', async ({ page, request }) => {
+  await login(page, adminUsername, adminPassword);
+  const token = await createToken(page, 'stats-missing-params-token');
+
+  const response = await request.get(`${baseUrl}/api/schedules/stats`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  expect(response.status()).toBe(400);
+  await expect(response.json()).resolves.toMatchObject({
+    error: {
+      code: 'INVALID_INPUT',
+    },
+  });
+});
+
+test('Bearer Token 返回含节假日分类的年度值班统计', async ({ page, request }) => {
+  await login(page, adminUsername, adminPassword);
+  const token = await createToken(page, 'stats-yearly-token');
+
+  const response = await request.get(`${baseUrl}/api/schedules/stats?start=2026-01-01&end=2026-12-31`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  expect(response.status()).toBe(200);
+  await expect(response.json()).resolves.toEqual({
+    range: { start: '2026-01-01', end: '2026-12-31' },
+    total: 4,
+    userCount: 2,
+    stats: [
+      expect.objectContaining({
+        userId: 1,
+        userName: '张三',
+        count: 3,
+        restDayCount: 2,
+        holidayCount: 1,
+        adjustedWorkdayCount: 1,
+        restDays: [
+          { date: '2026-01-01', name: '元旦', type: 'holiday' },
+          { date: '2026-01-10', type: 'weekend' },
+        ],
+      }),
+      expect.objectContaining({
+        userId: 2,
+        userName: '李四',
+        count: 1,
+        restDayCount: 0,
+        holidayCount: 0,
+        adjustedWorkdayCount: 0,
+      }),
+    ],
+  });
+});
+
+test('stats 查询成功后写入 api_request 日志', async ({ page, request }) => {
+  await login(page, adminUsername, adminPassword);
+  const token = await createToken(page, 'stats-api-log-token');
+
+  const response = await request.get(`${baseUrl}/api/schedules/stats?start=2026-01-01&end=2026-12-31`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  expect(response.status()).toBe(200);
+
+  const log = db.prepare(`
+    SELECT action, target, new_value, operator_username, operator_role, source
+    FROM logs
+    WHERE action = 'api_request'
+    ORDER BY id DESC
+    LIMIT 1
+  `).get() as {
+    action: string;
+    target: string;
+    new_value: string | null;
+    operator_username: string | null;
+    operator_role: string | null;
+    source: string | null;
+  };
+
+  expect(log).toMatchObject({
+    action: 'api_request',
+    target: 'GET /api/schedules/stats 200',
+    new_value: 'OK',
+    operator_username: 'token:stats-api-log-token',
+    operator_role: 'admin',
+    source: 'api',
+  });
+});

--- a/tests/duty-summary.test.mjs
+++ b/tests/duty-summary.test.mjs
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const modulePath = new URL('../src/lib/duty-summary.ts', import.meta.url).href;
+
+async function loadModule() {
+  return import(`${modulePath}?t=${Date.now()}-${Math.random()}`);
+}
+
+// 使用的 2026 年已知日期（数据来源 src/lib/holidays.ts）：
+//  - 2026-01-01  元旦（法定节假日）
+//  - 2026-01-04  元旦调休补班（isWorkday，算工作日）
+//  - 2026-01-05  周一（普通工作日）
+//  - 2026-01-10  周六（普通周末）
+//  - 2026-02-15  春节（法定节假日）
+
+test('休息日分类：节假日 / 周末 / 调休补班 分别计数', async () => {
+  const { summarizeDutyDates } = await loadModule();
+
+  const summary = summarizeDutyDates([
+    '2026-01-01', // 元旦（节假日）
+    '2026-01-04', // 调休补班（工作日）
+    '2026-01-05', // 周一（工作日）
+    '2026-01-10', // 周六（周末）
+    '2026-02-15', // 春节（节假日）
+  ]);
+
+  assert.equal(summary.holidayCount, 2, '元旦 + 春节 = 2 个法定节假日');
+  assert.equal(summary.restDayCount, 3, '2 节假日 + 1 周末 = 3 个非工作日');
+  assert.equal(summary.adjustedWorkdayCount, 1, '元旦 1 月 4 日补班');
+});
+
+test('restDays 按日期升序返回，节假日带名称、周末无名称', async () => {
+  const { summarizeDutyDates } = await loadModule();
+
+  const summary = summarizeDutyDates([
+    '2026-02-15', // 春节
+    '2026-01-01', // 元旦
+    '2026-01-10', // 周六
+  ]);
+
+  assert.deepEqual(summary.restDays, [
+    { date: '2026-01-01', name: '元旦', type: 'holiday' },
+    { date: '2026-01-10', type: 'weekend' },
+    { date: '2026-02-15', name: '春节', type: 'holiday' },
+  ]);
+});
+
+test('调休补班日不算休息日也不算节假日', async () => {
+  const { summarizeDutyDates } = await loadModule();
+
+  const summary = summarizeDutyDates(['2026-01-04']); // 元旦补班
+
+  assert.equal(summary.restDayCount, 0);
+  assert.equal(summary.holidayCount, 0);
+  assert.equal(summary.adjustedWorkdayCount, 1);
+  assert.deepEqual(summary.restDays, []);
+});
+
+test('空日期列表返回零计数', async () => {
+  const { summarizeDutyDates } = await loadModule();
+
+  const summary = summarizeDutyDates([]);
+
+  assert.equal(summary.restDayCount, 0);
+  assert.equal(summary.holidayCount, 0);
+  assert.equal(summary.adjustedWorkdayCount, 0);
+  assert.equal(summary.restDays.length, 0);
+});

--- a/tests/holiday-feed.test.mjs
+++ b/tests/holiday-feed.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const modulePath = new URL('../src/lib/holidays.ts', import.meta.url).href;
+const load = () => import(`${modulePath}?t=${Date.now()}-${Math.random()}`);
+
+test('isOffDay=true 解析为法定节假日（不带 isWorkday）', async () => {
+  const { parseHolidayCnDays } = await load();
+  const r = parseHolidayCnDays([{ name: '元旦', date: '2026-01-01', isOffDay: true }]);
+  assert.deepEqual(r, [{ name: '元旦', date: '2026-01-01' }]);
+});
+
+test('isOffDay=false 解析为调休补班（isWorkday=true）', async () => {
+  const { parseHolidayCnDays } = await load();
+  const r = parseHolidayCnDays([{ name: '元旦', date: '2026-01-04', isOffDay: false }]);
+  assert.deepEqual(r, [{ name: '元旦', date: '2026-01-04', isWorkday: true }]);
+});
+
+test('跳过字段缺失或日期格式错误的条目', async () => {
+  const { parseHolidayCnDays } = await load();
+  const r = parseHolidayCnDays([
+    { name: '元旦', date: '2026-01-01', isOffDay: true },
+    { name: '坏日期', date: 'not-a-date', isOffDay: true },
+    { name: '缺isOffDay', date: '2026-01-02' },
+    { date: '2026-01-03', isOffDay: true },
+    'garbage',
+    null,
+  ]);
+  assert.deepEqual(r, [{ name: '元旦', date: '2026-01-01' }]);
+});
+
+test('真实 holiday-cn 2026 片段：元旦假期 + 补班解析正确', async () => {
+  const { parseHolidayCnDays } = await load();
+  const r = parseHolidayCnDays([
+    { name: '元旦', date: '2026-01-01', isOffDay: true },
+    { name: '元旦', date: '2026-01-02', isOffDay: true },
+    { name: '元旦', date: '2026-01-03', isOffDay: true },
+    { name: '元旦', date: '2026-01-04', isOffDay: false },
+  ]);
+  assert.equal(r.length, 4);
+  assert.equal(r[0].isWorkday, undefined); // 假期
+  assert.equal(r[3].isWorkday, true);      // 补班
+});

--- a/tests/stats-range.test.mjs
+++ b/tests/stats-range.test.mjs
@@ -58,3 +58,32 @@ test('什么参数都没给返回 null', async () => {
   assert.equal(resolveStatsRange({}), null);
   assert.equal(resolveStatsRange({ start: '2026-01-01' }), null); // 只有 start 没 end
 });
+
+test('holidayYearsForRange：单年查询含相邻年（边界日期存在相邻年份文件里）', async () => {
+  const { holidayYearsForRange } = await load();
+  assert.deepEqual(holidayYearsForRange('2026-01-01', '2026-12-31'), [2025, 2026, 2027]);
+});
+
+test('holidayYearsForRange：跨年查询展开相邻年且去重', async () => {
+  const { holidayYearsForRange } = await load();
+  assert.deepEqual(holidayYearsForRange('2024-06-01', '2026-06-01'), [2023, 2024, 2025, 2026, 2027]);
+});
+
+test('holidayYearsForRange：跨度在上限内（10 年）返回结果', async () => {
+  const { holidayYearsForRange } = await load();
+  const years = holidayYearsForRange('2020-01-01', '2029-12-31'); // 10 年
+  assert.ok(years !== null);
+  assert.equal(years[0], 2019);
+  assert.equal(years[years.length - 1], 2030);
+});
+
+test('holidayYearsForRange：跨度超上限返回 null（防 fan-out 滥用）', async () => {
+  const { holidayYearsForRange } = await load();
+  assert.equal(holidayYearsForRange('2020-01-01', '2030-12-31'), null); // 11 年
+  assert.equal(holidayYearsForRange('0000-01-01', '9999-12-31'), null); // 极端
+});
+
+test('holidayYearsForRange：非法年份返回 null', async () => {
+  const { holidayYearsForRange } = await load();
+  assert.equal(holidayYearsForRange('foo-01-01', '2026-12-31'), null);
+});

--- a/tests/stats-range.test.mjs
+++ b/tests/stats-range.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const modulePath = new URL('../src/lib/stats-range.ts', import.meta.url).href;
+const load = () => import(`${modulePath}?t=${Date.now()}-${Math.random()}`);
+
+test('显式 start+end 原样透传', async () => {
+  const { resolveStatsRange } = await load();
+  assert.deepEqual(
+    resolveStatsRange({ start: '2026-01-01', end: '2026-12-31' }),
+    { start: '2026-01-01', end: '2026-12-31' },
+  );
+});
+
+test('start+end 优先级高于 year/month', async () => {
+  const { resolveStatsRange } = await load();
+  assert.deepEqual(
+    resolveStatsRange({ start: '2026-03-01', end: '2026-03-31', month: '2026-06', year: '2027' }),
+    { start: '2026-03-01', end: '2026-03-31' },
+  );
+});
+
+test('month=2026-06 解析为整月范围', async () => {
+  const { resolveStatsRange } = await load();
+  assert.deepEqual(resolveStatsRange({ month: '2026-06' }), { start: '2026-06-01', end: '2026-06-30' });
+});
+
+test('month=2024-02（闰年）末尾为 29 日', async () => {
+  const { resolveStatsRange } = await load();
+  assert.deepEqual(resolveStatsRange({ month: '2024-02' }), { start: '2024-02-01', end: '2024-02-29' });
+});
+
+test('month=2026-02（平年）末尾为 28 日', async () => {
+  const { resolveStatsRange } = await load();
+  assert.deepEqual(resolveStatsRange({ month: '2026-02' }), { start: '2026-02-01', end: '2026-02-28' });
+});
+
+test('year=2026 解析为整年范围', async () => {
+  const { resolveStatsRange } = await load();
+  assert.deepEqual(resolveStatsRange({ year: '2026' }), { start: '2026-01-01', end: '2026-12-31' });
+});
+
+test('非法 month（13 月、格式错）返回 null', async () => {
+  const { resolveStatsRange } = await load();
+  assert.equal(resolveStatsRange({ month: '2026-13' }), null);
+  assert.equal(resolveStatsRange({ month: '2026-6' }), null);
+  assert.equal(resolveStatsRange({ month: 'abcd' }), null);
+});
+
+test('非法 year 返回 null', async () => {
+  const { resolveStatsRange } = await load();
+  assert.equal(resolveStatsRange({ year: '26' }), null);
+  assert.equal(resolveStatsRange({ year: 'abcd' }), null);
+});
+
+test('什么参数都没给返回 null', async () => {
+  const { resolveStatsRange } = await load();
+  assert.equal(resolveStatsRange({}), null);
+  assert.equal(resolveStatsRange({ start: '2026-01-01' }), null); // 只有 start 没 end
+});


### PR DESCRIPTION
## 概述

新增对外 API 端点 `GET /api/schedules/stats`，把原先仅内部「统计」页面可用的值班统计能力开放给外部调用方，并补齐节假日维度分类与按年自动拉取。

- closes: 将 dashboard 内部的 `getStats` 能力以 REST 形式暴露

## 改动

### 1. `GET /api/schedules/stats`（新端点）
Bearer token 鉴权（与 `/api/schedules` 同模式），写入 `api_request` 日志。时间参数三选一：

| 参数 | 示例 | 解析为 |
|---|---|---|
| `start` + `end` | `?start=2026-01-01&end=2026-12-31` | 原样 |
| `year` | `?year=2026` | 整年 `01-01 ~ 12-31` |
| `month` | `?month=2026-06` | 整月（自动处理闰年 2 月） |

```bash
curl -H "Authorization: Bearer <token>" \
  "https://scheduling.zweien.xyz/api/schedules/stats?year=2026"
```

```json
{
  "range": { "start": "2026-01-01", "end": "2026-12-31" },
  "total": 4, "userCount": 2,
  "stats": [{
    "userId": 1, "userName": "张三", "count": 3,
    "restDayCount": 2,        // 非工作日值班（节假日+周末）
    "holidayCount": 1,        // 法定节假日值班（如元旦）
    "adjustedWorkdayCount": 1,// 调休补班值班
    "dates": ["2026-01-01", "2026-01-04", "2026-01-10"],
    "restDays": [
      { "date": "2026-01-01", "name": "元旦", "type": "holiday" },
      { "date": "2026-01-10", "type": "weekend" }
    ]
  }]
}
```

### 2. 节假日按年自动拉取
`src/lib/holidays.ts` 运行时从 [NateScarlet/holiday-cn](https://github.com/NateScarlet/holiday-cn)（基于国务院通知，MIT）按年拉取，**覆盖**内置静态数据；拉取失败/超时自动**回退**到内置的 2025–2026 基线。端点计算前会对区间内的年份 best-effort 预加载。

## 新增纯函数（均有单测）
- `resolveStatsRange({start,end,year,month})` — 时间参数归一化（含闰年 2 月末）
- `summarizeDutyDates(dates)` — 值班日期分类为 节假日/周末/调休补班
- `parseHolidayCnDays(days)` — holiday-cn 数据解析

## 验证
- ✅ 单元测试 17/17 通过（`duty-summary` 4 + `stats-range` 9 + `holiday-feed` 4），TDD 先红后绿
- ✅ `tsc --noEmit`：新文件 0 错误（仓库另有 12 个既有错误与本次无关）
- ✅ ESLint：新文件干净
- ✅ 真实 dev server 端到端实测：
  - `?year=2026` / `?month=2026-01` / 无参数→400 均符合预期
  - **动态拉取实测**：用 2024 年（不在静态基线）造数，元旦被正确识别为节假日、`2024-02-04`（周日春节补班）被正确识别为工作日 → 证明按年拉取链路打通
- ⚠️ Playwright 浏览器用例（`tests/api-schedules-stats.spec.ts` 的 400/200/日志三条）已按项目惯例写好；本地因 chromium 下载受阻未跑，CI 环境可直接运行

## 备注
- 节假日数据为静态 + 远程兜底；若 holiday-cn 未发布某年（如 2027 目前 `days: []`），该年会回退为按周末判断。
- 未改动既有 UI / 数据库结构。
