### PR TITLE
feat(skill): 新增 scheduling-api skill（终端调用值班系统 API）

### DIFF
--- a/.claude/skills/scheduling-api/SKILL.md
+++ b/.claude/skills/scheduling-api/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: scheduling-api
+description: Operate the 值班排班系统 (duty-scheduling system) through its REST API — query who is on duty, swap/change a day's assignment, get duty statistics (with holiday breakdown), export the monthly roster. Use whenever the user wants to interact with the scheduling/值班/排班 system from the terminal, e.g. "查一下本周谁值班", "把下周三的值班换成张三", "统计今年每个人值班几次", "导出本月值班表", "今年节假日值班情况", or mentions scheduling.zweien.xyz / the scheduling repo / 值班表 / 调班 / 换班. Auth and base URL are handled by the bundled scripts/api.sh helper reading .env.
+---
+
+# scheduling-api — 值班系统 API 操作
+
+This skill lets you drive the duty-scheduling system (`zweien/scheduling`) from the command line: query rosters, change who's on duty, pull statistics, export schedules. All calls go through one helper that injects auth, so you never handle the token by hand.
+
+## 前置条件（一次性）
+
+The API requires a **Bearer token**. Tokens are created from the **web UI** (login → 设置/Token 管理 → 新建), not via the API itself — `POST /api/tokens` needs a login session, so do it once in the browser.
+
+Put the token in the repo root `.env` (this file is gitignored, so it stays local):
+
+```bash
+# .env  （从 skill 的 assets/env.example 复制后填写）
+SCHEDULING_API_TOKEN=sch_xxxxxxxxxxxxxxxxxxxxxxxx
+SCHEDULING_BASE_URL=http://localhost:3000   # 开发；线上用 https://scheduling.zweien.xyz
+```
+
+If `.env` is missing or the token is empty, the helper prints a clear error.
+
+**Token role matters:** query/stats/export work with any token; **changing duty (`PATCH ...`) requires an admin token.** A non-admin token gets `403 FORBIDDEN`.
+
+## 如何调用
+
+Use the bundled helper — it loads `.env`, adds the `Authorization: Bearer …` header, and appends an `HTTP_STATUS:NNN` line to the output so you can tell success from failure:
+
+```bash
+bash .claude/skills/scheduling-api/scripts/api.sh METHOD "/path" 'optional-json-body'
+```
+
+Always run from the repo root (that's where `.env` lives). Parse the trailing `HTTP_STATUS:` line: `200` = OK, `400` = bad input, `401` = token missing/invalid, `403` = token lacks admin role.
+
+## 能力清单
+
+### 查询（GET，任意 token）
+
+```bash
+# 某段时间的值班（返回每天的值班人）
+bash .claude/skills/scheduling-api/scripts/api.sh GET "/api/schedules?start=2026-07-01&end=2026-07-31"
+
+# 全部值班人员
+bash .claude/skills/scheduling-api/scripts/api.sh GET "/api/users"
+
+# 领导值班 / 领导列表
+bash .claude/skills/scheduling-api/scripts/api.sh GET "/api/leader-schedules?start=2026-07-01&end=2026-07-31"
+bash .claude/skills/scheduling-api/scripts/api.sh GET "/api/leaders"
+```
+
+### 换班 / 改排班（PATCH，需 admin token）
+
+把某一天的值班人换成指定 userId（改后该天标记为手动调整 `isManual:true`，自动排班会保留）：
+
+```bash
+bash .claude/skills/scheduling-api/scripts/api.sh PATCH "/api/schedules/2026-07-15" '{"userId":3}'
+# 领导值班同理：
+bash .claude/skills/scheduling-api/scripts/api.sh PATCH "/api/leader-schedules/2026-07-15" '{"leaderId":2}'
+```
+
+要换班时先 `GET /api/users` 拿到 `userId`/`name` 对应关系，再 PATCH 目标日期。日期格式 `YYYY-MM-DD`。
+
+### 统计（GET，任意 token）— `/api/schedules/stats`
+
+时间参数三选一：`year`、`month`（`YYYY-MM`）、或 `start`+`end`。
+
+```bash
+bash .claude/skills/scheduling-api/scripts/api.sh GET "/api/schedules/stats?year=2026"
+bash .claude/skills/scheduling-api/scripts/api.sh GET "/api/schedules/stats?month=2026-07"
+```
+
+返回 `{range,total,userCount,stats[]}`，每人含值班次数及节假日维度分类。字段含义（用户常问，解释清楚）：
+
+| 字段 | 含义 |
+|---|---|
+| `count` | 区间内值班天数 |
+| `restDayCount` | 非工作日值班（法定节假日 + 周末 − 调休补班） |
+| `holidayCount` | **法定节假日**值班天数（如元旦、春节） |
+| `adjustedWorkdayCount` | **调休补班**值班天数——周末被官方定为工作日的那天 |
+| `restDays` | 非工作日明细：`type=holiday`（带 `name`）或 `weekend` |
+
+> 跨度上限 10 年；超过返回 400。节假日按年自动拉取（NateScarlet/holiday-cn），失败回退到内置 2025–2026。
+
+### 导出（GET，任意 token）
+
+```bash
+# 当月值班表 Markdown
+bash .claude/skills/scheduling-api/scripts/api.sh GET "/api/schedules/monthly-markdown?month=2026-07"
+```
+
+### Token 管理
+
+`GET/POST/PATCH /api/tokens` 走**登录 session**（不是 Bearer），因此不通过本助手创建/列出。如需新 token：浏览器登录 → Token 管理页。
+
+## 实用模式
+
+- **"谁本周值班"** → 算出本周一~周日的 `YYYY-MM-DD`，`GET /api/schedules?start=…&end=…`，按 `user.name` 汇总。
+- **"把 X 换成 Y"** → 先 `GET /api/users` 找到 Y 的 `userId`，再 `PATCH /api/schedules/<date>`；可用 `GET /api/schedules?start=<date>&end=<date>` 复核。
+- **"今年谁值班最多 / 节假日值班几次"** → `GET /api/schedules/stats?year=<年>`，看 `count` 排序与 `holidayCount`。
+- 结果是 JSON 时，用 `jq` 等工具格式化更易读（如 `… | jq .`）。

--- a/.claude/skills/scheduling-api/assets/env.example
+++ b/.claude/skills/scheduling-api/assets/env.example
@@ -1,0 +1,10 @@
+# 复制本文件到仓库根目录并改名为 .env，然后填入你的 token。
+# .env 已被 .gitignore 忽略，不会提交。
+#
+# 获取 token：浏览器登录值班系统 → 设置/Token 管理 → 新建。
+# 查询/统计/导出用任意 token 即可；换班(PATCH)需要 admin 角色的 token。
+
+SCHEDULING_API_TOKEN=sch_xxxxxxxxxxxxxxxxxxxxxxxx
+
+# 开发默认 http://localhost:3000；线上用 https://scheduling.zweien.xyz
+SCHEDULING_BASE_URL=http://localhost:3000

--- a/.claude/skills/scheduling-api/scripts/api.sh
+++ b/.claude/skills/scheduling-api/scripts/api.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# scheduling-api 助手：用 .env 里的 Bearer token 调用值班系统 REST API。
+# 用法: api.sh METHOD path [json-body]
+# 示例: api.sh GET "/api/schedules/stats?year=2026"
+#       api.sh PATCH "/api/schedules/2026-07-15" '{"userId":3}'
+set -euo pipefail
+
+# 从本脚本位置向上查找最近的 .env（仓库根目录）
+d="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+while [ "$d" != "/" ] && [ ! -f "$d/.env" ]; do d="$(dirname "$d")"; done
+if [ -f "$d/.env" ]; then set -a; . "$d/.env"; set +a; fi
+
+: "${SCHEDULING_BASE_URL:=http://localhost:3000}"
+
+if [ -z "${SCHEDULING_API_TOKEN:-}" ]; then
+  echo "ERROR: SCHEDULING_API_TOKEN 未设置。请在仓库根目录的 .env 中配置（见 skill 的 assets/env.example）。" >&2
+  exit 2
+fi
+
+METHOD="${1:?用法: api.sh METHOD path [json-body]}"
+PATH_="${2:?用法: api.sh METHOD path [json-body]}"
+BODY="${3:-}"
+
+extra=()
+if [ -n "$BODY" ]; then
+  extra=(-H "Content-Type: application/json" -d "$BODY")
+fi
+
+# -sS 静默但报错；末尾追加 HTTP_STATUS 行便于解析
+exec curl -sS -X "$METHOD" "$SCHEDULING_BASE_URL$PATH_" \
+  -H "Authorization: Bearer $SCHEDULING_API_TOKEN" \
+  "${extra[@]}" \
+  -w '\nHTTP_STATUS:%{http_code}\n'


### PR DESCRIPTION
## 概述

新增项目级 skill **`scheduling-api`**，让 Claude 能在终端直接通过 REST API 操作值班系统：查询、换班、统计、导出。

## 文件

```
.claude/skills/scheduling-api/
├── SKILL.md            # 触发说明 + 全端点目录 + 示例 + 节假日字段说明
├── scripts/api.sh      # 助手：自动读 .env、注入 Bearer、追加 HTTP_STATUS 行
└── assets/env.example  # .env 模板（.env 已被 gitignore）
```

## 覆盖能力

| 能力 | 端点 | 鉴权 |
|---|---|---|
| 查询值班 / 人员 / 领导 | `GET /api/schedules`、`/api/users`、`/api/leaders`、`/api/leader-schedules` | 任意 token |
| 换班 / 改排班 | `PATCH /api/schedules/:date`、`/api/leader-schedules/:date` | **admin** token |
| 统计（含节假日分类） | `GET /api/schedules/stats?year=\|month=\|start+end` | 任意 token |
| 导出月度值班表 | `GET /api/schedules/monthly-markdown?month=` | 任意 token |

## 设计要点

- **Token 走 `.env`**（`SCHEDULING_API_TOKEN`），不进对话上下文；token 创建仍在 Web UI（`/api/tokens` 为 session 鉴权，非 Bearer）。
- 助手从脚本位置向上查找 `.env`，`SCHEDULING_BASE_URL` 默认 `http://localhost:3000`（线上可在 `.env` 覆盖）。
- 输出末尾追加 `HTTP_STATUS:NNN`，便于判断 200/400/401/403。

## 验证

启动 dev server、写入临时 `.env`（admin token），通过 `api.sh` 实测五项能力全部 `HTTP 200`：查询人员、查询值班、换班（PATCH）、统计、导出 markdown。验证后已删除临时 `.env`、还原 DB，未泄露 token。

## 使用

```bash
cp .claude/skills/scheduling-api/assets/env.example .env
# 填入浏览器里创建的 token，然后：
bash .claude/skills/scheduling-api/scripts/api.sh GET "/api/schedules/stats?year=2026"
```
